### PR TITLE
Fix `yarn clean` at the root

### DIFF
--- a/apps/super-rentals/package.json
+++ b/apps/super-rentals/package.json
@@ -17,7 +17,8 @@
     "lint:js": "eslint .",
     "start": "ember serve",
     "test": "npm-run-all lint:* test:*",
-    "test:ember": "ember test"
+    "test:ember": "ember test",
+    "clean": "shx rm -rf dist tmp"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
@@ -51,7 +52,8 @@
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit-dom": "^1.2.0"
+    "qunit-dom": "^1.2.0",
+    "shx": "*"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10634,7 +10634,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shx@^0.3.2:
+shx@*, shx@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.2.tgz#40501ce14eb5e0cbcac7ddbd4b325563aad8c123"
   integrity sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==


### PR DESCRIPTION
`yarn workspaces run clean` expects each workspace to have a clean script, so added on for super-rentals.